### PR TITLE
Expose Downloader handler role arn and make tests specific to UTC

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,8 +181,8 @@ The deployment relies on an S3 Bucket being available to upload images to. The B
 
 This is **required** in standard deployments, for integration deployments, a bucket is created and setup for you.
 
-You must allow the `downloader` function `read` and `write` permissions to your bucket, you can find the ARN of the `downloader` function in
-SSM Parameter Store [here](https://us-west-2.console.aws.amazon.com/systems-manager/parameters/) under the name `integration_tests/<IDENTIFIER>/downloader_arn`. Navigate to the function and use its Execution Role ARN within the Buckets permissions to allow access.
+You must allow the `downloader` function `read` and `write` permissions to your bucket, you can find the ARN of the `downloader` functions execution role in
+SSM Parameter Store [here](https://us-west-2.console.aws.amazon.com/systems-manager/parameters/) under the name `integration_tests/<IDENTIFIER>/downloader_role_arn`. Use this within the Buckets permissions to allow access.
 
 
 ## Standard Deployments

--- a/README.md
+++ b/README.md
@@ -184,6 +184,28 @@ This is **required** in standard deployments, for integration deployments, a buc
 You must allow the `downloader` function `read` and `write` permissions to your bucket, you can find the ARN of the `downloader` functions execution role in
 SSM Parameter Store [here](https://us-west-2.console.aws.amazon.com/systems-manager/parameters/) under the name `integration_tests/<IDENTIFIER>/downloader_role_arn`. Use this within the Buckets permissions to allow access.
 
+Your Bucket Policy will look like:
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "<downloader-role-arn>"
+            },
+            "Action": [
+                "s3:PutObject",
+                "s3:Abort"
+            ],
+            "Resource": [
+                "arn:aws:s3:::<bucket-name>/*",
+            ]
+        }
+    ]
+}
+```
 
 ## Standard Deployments
 

--- a/cdk/app_integration.py
+++ b/cdk/app_integration.py
@@ -21,7 +21,7 @@ downloader_stack = DownloaderStack(
     scihub_url=integration_stack.scihub_url,
 )
 
-integration_stack.upload_bucket.grant_read_write(downloader_stack.downloader)
+integration_stack.upload_bucket.grant_put(downloader_stack.downloader)
 
 for k, v in {
     "Project": "hls-s2-downloader-serverless",

--- a/cdk/downloader_stack.py
+++ b/cdk/downloader_stack.py
@@ -289,6 +289,13 @@ class DownloaderStack(core.Stack):
             parameter_name=f"/integration_tests/{identifier}/downloader_arn",
         )
 
+        aws_ssm.StringParameter(
+            self,
+            id=f"{identifier}-downloader-role-arn",
+            string_value=self.downloader.role.role_arn,
+            parameter_name=(f"/integration_tests/{identifier}/downloader_role_arn"),
+        )
+
         self.downloader.role.add_managed_policy(lambda_insights_policy)
 
         downloader_rds.secret.grant_read(link_fetcher)


### PR DESCRIPTION
## What I am changing

TL;DR: This PR exposes the Downloader handlers role arn as an SSM Parameter, so that the Bucket which will contain the downloaded images can give the handler permission to read/write to it.

## How I did it

* `cdk/downloader_stack.py`:
  * Add a new `StringParameter` for the Downloaders role
* `cdk/app_integration.py`:
  * Limit the downloaders permissions to `put` on the download bucket
* `integration_tests/test_downloading.py`:
  * Set the datetimes we use to UTC as this is what AWS uses (Stops tests run in a non UTC timezone failing I.E. BST)
* `README.md`:
  * Update bucket instructions to use the role arn rather than the function arn

## How you can test it

Deploy with:

```bash
$ make deploy-integration
```

Test with:

```bash
$ make integration-tests
```

Destroy with:

```bash
$ make destroy-integration
```
