### PR TITLE
Disable auto minor version upgrades

### DIFF
--- a/cdk/downloader_stack.py
+++ b/cdk/downloader_stack.py
@@ -81,6 +81,7 @@ class DownloaderStack(core.Stack):
                 vpc=vpc,
                 security_groups=[rds_security_group],
                 publicly_accessible=True,
+                auto_minor_version_upgrade=False,
             ),
             subnet_group=rds_subnet_group,
             default_database_name="hlss2downloader",


### PR DESCRIPTION
## What I am changing

The postgres version of the RDS deployment was upgraded automatically by AWS which breaks CloudFormation.

## How I did it

Add the flag `auto_minor_version_upgrade=False,`

## How you can test it

This should result in no upgrades being performed automatically by AWS