### PR TITLE
Remove available_links from link_fetching function as we didn't use it

### DIFF
--- a/lambdas/link_fetcher/handler.py
+++ b/lambdas/link_fetcher/handler.py
@@ -29,7 +29,7 @@ def handler(event, context):
     updated_total_results = False
     day = datetime.strptime(event["query_date"], "%Y-%m-%d").date()
 
-    available_links, fetched_links = get_available_and_fetched_links(session_maker, day)
+    fetched_links = get_fetched_links(session_maker, day)
     params = get_query_parameters(fetched_links, day)
 
     while keep_querying_for_imagery:
@@ -118,21 +118,17 @@ def add_scihub_result_to_sqs(
     )
 
 
-def get_available_and_fetched_links(
-    session_maker: sessionmaker, day: date
-) -> Tuple[int, int]:
+def get_fetched_links(session_maker: sessionmaker, day: date) -> int:
     """
-    For a given day, return the values for total `available_links` and total
-    `fetched_links`, where `available_links` is the total number of results for the day
-    from SciHub and `fetched_links` is the total number of granules that have been
-    processed (but not necessarily added to the database because of filtering)
+    For a given day, return the total
+    `fetched_links`, where `fetched_links` is the total number of granules that have
+    been processed (but not necessarily added to the database because of filtering)
 
     If no entry is found, one is created
     :param session_maker: sessionmaker representing the SQLAlchemy sessionmaker to use
         for database interactions
     :param day: date representing the day to return results for
-    :returns: Tuple[int, int] representing a tuple of
-        (`available_links`, `fetched_links)
+    :returns: int representing `fetched_links`
     """
     with get_session(session_maker) as db:
         granule_count = db.query(GranuleCount).filter(GranuleCount.date == day).first()
@@ -145,9 +141,9 @@ def get_available_and_fetched_links(
             )
             db.add(granule_count)
             db.commit()
-            return (0, 0)
+            return 0
         else:
-            return (granule_count.available_links, granule_count.fetched_links)
+            return granule_count.fetched_links
 
 
 def update_total_results(session_maker: sessionmaker, day: date, total_results: int):
@@ -161,7 +157,7 @@ def update_total_results(session_maker: sessionmaker, day: date, total_results: 
     """
     with get_session(session_maker) as db:
         granule_count = db.query(GranuleCount).filter(GranuleCount.date == day).first()
-        granule_count.available_links = total_results
+        granule_count.available_links += total_results
         db.commit()
 
 

--- a/lambdas/link_fetcher/handler.py
+++ b/lambdas/link_fetcher/handler.py
@@ -157,7 +157,7 @@ def update_total_results(session_maker: sessionmaker, day: date, total_results: 
     """
     with get_session(session_maker) as db:
         granule_count = db.query(GranuleCount).filter(GranuleCount.date == day).first()
-        granule_count.available_links += total_results
+        granule_count.available_links = total_results
         db.commit()
 
 

--- a/lambdas/link_fetcher/tests/test_link_fetcher_handler.py
+++ b/lambdas/link_fetcher/tests/test_link_fetcher_handler.py
@@ -331,7 +331,7 @@ def test_that_link_fetcher_handler_correctly_retrieves_fetched_links_if_not_in_d
 def test_that_link_fetcher_handler_correctly_updates_available_links_in_db(
     db_session, db_session_context
 ):
-    expected_available_links = 750
+    expected_available_links = 500
     db_session.add(
         GranuleCount(
             date=datetime(2020, 1, 1),

--- a/lambdas/link_fetcher/tests/test_link_fetcher_handler.py
+++ b/lambdas/link_fetcher/tests/test_link_fetcher_handler.py
@@ -17,7 +17,7 @@ from handler import (
     ensure_three_decimal_points_for_milliseconds_and_replace_z,
     filter_scihub_results,
     get_accepted_tile_ids,
-    get_available_and_fetched_links,
+    get_fetched_links,
     get_page_for_query_and_total_results,
     get_query_parameters,
     get_scihub_auth,
@@ -288,15 +288,14 @@ def test_that_link_fetcher_handler_correctly_adds_scihub_result_to_queue(
     assert_that(scihub_result_filename).is_equal_to(message_body["filename"])
 
 
-def test_that_link_fetcher_handler_correctly_retrieves_available_and_fetched_links_if_in_db(  # noqa
+def test_that_link_fetcher_handler_correctly_retrieves_fetched_links_if_in_db(  # noqa
     db_session, db_session_context
 ):
-    expected_available_links = 1000
     expected_fetched_links = 400
     db_session.add(
         GranuleCount(
             date=datetime(2020, 1, 1),
-            available_links=expected_available_links,
+            available_links=0,
             fetched_links=expected_fetched_links,
             last_fetched_time=datetime(2020, 1, 1, 0, 0, 0),
         )
@@ -304,26 +303,19 @@ def test_that_link_fetcher_handler_correctly_retrieves_available_and_fetched_lin
     db_session.commit()
 
     with patch("handler.get_session", db_session_context):
-        actual_available_links, actual_fetched_links = get_available_and_fetched_links(
-            None, datetime(2020, 1, 1)
-        )
-        assert_that(expected_available_links).is_equal_to(actual_available_links)
+        actual_fetched_links = get_fetched_links(None, datetime(2020, 1, 1))
         assert_that(expected_fetched_links).is_equal_to(actual_fetched_links)
 
 
 @freeze_time("2020-12-31 10:10:10")
-def test_that_link_fetcher_handler_correctly_retrieves_available_and_fetched_links_if_not_in_db(  # noqa
+def test_that_link_fetcher_handler_correctly_retrieves_fetched_links_if_not_in_db(  # noqa
     db_session, db_session_context
 ):
-    expected_available_links = 0
     expected_fetched_links = 0
     expected_last_fetched_time = datetime.now()
 
     with patch("handler.get_session", db_session_context):
-        actual_available_links, actual_fetched_links = get_available_and_fetched_links(
-            None, datetime(2020, 12, 31)
-        )
-        assert_that(expected_available_links).is_equal_to(actual_available_links)
+        actual_fetched_links = get_fetched_links(None, datetime(2020, 12, 31))
         assert_that(expected_fetched_links).is_equal_to(actual_fetched_links)
 
     actual_last_fetched_time = (
@@ -339,7 +331,7 @@ def test_that_link_fetcher_handler_correctly_retrieves_available_and_fetched_lin
 def test_that_link_fetcher_handler_correctly_updates_available_links_in_db(
     db_session, db_session_context
 ):
-    expected_available_links = 500
+    expected_available_links = 750
     db_session.add(
         GranuleCount(
             date=datetime(2020, 1, 1),


### PR DESCRIPTION
## What I am changing

This removes the `available_links` from `get_available_and_fetched_links` as it wasn't used.

Each time a day is queried, we replace the total results with the new total results, this is because this number will likely increase when more data is ingested.

## How I did it

Removed `available_links` from `get_available_and_fetched_links` in `lambdas/link_fetcher/handler.py`

## How you can test it

Run the tests 🎉 
