### PR TITLE
Increase downloader memory to improve network I/O capacity.

### DIFF
--- a/cdk/downloader_stack.py
+++ b/cdk/downloader_stack.py
@@ -256,7 +256,7 @@ class DownloaderStack(core.Stack):
             index="handler.py",
             handler="handler",
             layers=[db_layer, psycopg2_layer, insights_layer],
-            memory_size=1200,
+            memory_size=3600,
             timeout=core.Duration.minutes(15),
             runtime=aws_lambda.Runtime.PYTHON_3_8,
             environment=downloader_environment_vars,


### PR DESCRIPTION
## What I am changing
Increasing the memory of the downloader lambda to increase network I/O capacity.

## How I did it
Changed the value in the CDK stack.

## How you can test it
Deploy and review average execution times in the Cloudwatch metrics.