### PR TITLE
Stream locking

### DIFF
--- a/cdk/downloader_stack.py
+++ b/cdk/downloader_stack.py
@@ -260,7 +260,7 @@ class DownloaderStack(core.Stack):
             timeout=core.Duration.minutes(15),
             runtime=aws_lambda.Runtime.PYTHON_3_8,
             environment=downloader_environment_vars,
-            reserved_concurrent_executions=15,
+            reserved_concurrent_executions=24,
         )
 
         aws_logs.LogGroup(

--- a/integration_tests/test_link_fetching.py
+++ b/integration_tests/test_link_fetching.py
@@ -43,7 +43,7 @@ def test_that_link_fetching_invocation_executes_correctly(
         assert_that(granules).is_length(68)
 
         granule_counts = db.query(GranuleCount).all()
-        assert_that(granule_counts).is_length(21)
+        assert_that(granule_counts).is_length(5)
 
         statuses = db.query(Status).all()
         assert_that(statuses).is_length(1)
@@ -103,7 +103,7 @@ def test_that_link_fetching_invocation_executes_correctly_when_a_duplicate_granu
         assert_that(granule_we_inserted.download_url).is_equal_to("A download url")
 
         granule_counts = db.query(GranuleCount).all()
-        assert_that(granule_counts).is_length(21)
+        assert_that(granule_counts).is_length(5)
 
         statuses = db.query(Status).all()
         assert_that(statuses).is_length(1)

--- a/lambdas/date_generator/handler.py
+++ b/lambdas/date_generator/handler.py
@@ -8,12 +8,12 @@ def handler(event, context):
 
 def get_dates() -> List[str]:
     """
-    Returns 21 date strings from `datetime.now() - 1 day` with the latest day first
+    Returns 5 date strings from `datetime.now() - 1 day` with the latest day first
     Strings are formatted as %Y-%m-%d
     :returns: List[str] representing 21 days from yesterday
     """
     yesterdays_date = datetime.now().date() - timedelta(days=1)
     return [
         (yesterdays_date - timedelta(days=day)).strftime("%Y-%m-%d")
-        for day in range(0, 21)
+        for day in range(0, 5)
     ]

--- a/lambdas/date_generator/tests/test_date_generator_handler.py
+++ b/lambdas/date_generator/tests/test_date_generator_handler.py
@@ -9,7 +9,7 @@ from handler import get_dates, handler
 @freeze_time("2020-01-22")
 def test_that_get_dates_returns_correct_dates():
     expected_dates = [
-        datetime(2020, 1, i).date().strftime("%Y-%m-%d") for i in range(21, 0, -1)
+        datetime(2020, 1, i).date().strftime("%Y-%m-%d") for i in range(21, 16, -1)
     ]
     actual_dates = get_dates()
     assert_that(expected_dates).is_equal_to(actual_dates)
@@ -18,7 +18,7 @@ def test_that_get_dates_returns_correct_dates():
 @freeze_time("2020-04-22")
 def test_that_date_generator_handler_returns_correct_dates():
     expected_dates = [
-        datetime(2020, 4, i).date().strftime("%Y-%m-%d") for i in range(21, 0, -1)
+        datetime(2020, 4, i).date().strftime("%Y-%m-%d") for i in range(21, 16, -1)
     ]
     expected_handler_output = {"query_dates": expected_dates}
     actual_handler_output = handler(None, None)


### PR DESCRIPTION
## What I am changing
- Updating the downloader lambda usage of `requests` to use a `with` block to ensure connection closing.
- Reducing Scihub date search range.  IMPACT will be implementing a data backfill process so this will reduce throughput restrictions for previous dates.
- Increase concurrent connections for NASA 3 Inthub account increase.

## How I did it

## How you can test it
