### PR TITLE
fix: Install tox in deploy workflow (required for 'make deploy')

### DIFF
--- a/.github/workflows/deploy-on-release.yml
+++ b/.github/workflows/deploy-on-release.yml
@@ -23,6 +23,10 @@ jobs:
       - name: Install Pipenv
         run: curl https://raw.githubusercontent.com/pypa/pipenv/master/get-pipenv.py | python
 
+      - name: Install tox
+        run: |
+          pip install "tox>=3.18.0"
+
       - name: Get pipenv venv hashes
         id: hashes
         run: |


### PR DESCRIPTION
## What I am changing

This PR installs `tox` as part of the deployment workflow in order to resolve a deployment failure in https://github.com/NASA-IMPACT/hls-sentinel2-downloader-serverless/actions/runs/11601470881/job/32305213941#step:12:17

## How I did it

I copied the "Install tox" step from the integration workflow because that workflow had succeeded.

## How you can test it

I think this isn't very testable without something like [act](https://github.com/nektos/act) setup