### PR TITLE
fix: Set identifier to esa-prod for continuity

### DIFF
--- a/.github/workflows/deploy-on-release.yml
+++ b/.github/workflows/deploy-on-release.yml
@@ -190,7 +190,7 @@ jobs:
         run: |
           cat <<EOF >> .env
           OWNER="ci-developmentseed"
-          IDENTIFIER="prod"
+          IDENTIFIER="esa-prod"
           ENABLE_DOWNLOADING="TRUE"
           SCHEDULE_LINK_FETCHING="TRUE"
           USE_INTHUB2="TRUE"


### PR DESCRIPTION
## What I am changing

This PR updates the deploy step to point to the same stack that has been running (`esa-prod`, not `prod`). This change had happened as part of the switch to the ESA Copernicus services instead of IntHub. These changes weren't propagated back to "infrastructure as code" and the downloader stack wasn't redeployed using the `IDENTIFIER=prod` target, so this PR seeks to resolve this "drift"

I could see this going the other way (tear down "esa-prod" stack after getting "prod" to work) but there are a number of secrets that "esa-prod" has already configured

## How I did it

Find/replace

## How you can test it

Integration tests should still work and we'll have a fairly small `cdk diff` that mostly includes,

* Definition of Lambda assets is shorter in CDK v2 for the `S3Key` (no need to lookup refs from stack). Generally there's a few `.Ref` changes to be `.Fn::Sub`, which in other words means that the metadata is more directly specified
* Python 3.8 ~> 3.11 runtime
* A few StepFunction changes,
    * CDK v2 includes an extra AWS as defaults that retry will run on
    * The `Principal` in AssumeRolePolicyDocument for step function is now just `states.amazonaws.com`