### PR TITLE
fix: Update search limit to maximum to encompass <12k results without exce…

### DIFF
--- a/lambdas/link_fetcher/handler.py
+++ b/lambdas/link_fetcher/handler.py
@@ -300,7 +300,7 @@ def get_query_parameters(start: int, day: date) -> Mapping[str, Any]:
         "startDate": f"{oldest_acquisition_date.strftime('%Y-%m-%d')}T00:00:00Z",
         "sortParam": "published",
         "sortOrder": "desc",
-        "maxRecords": 100,
+        "maxRecords": 2000,
         # `start` is 0-based, but `index` is 1-based, so we must add 1
         "index": start + 1,
         # Fix for issue #28, due to breaking change in the OpenSearch API

--- a/lambdas/link_fetcher/tests/conftest.py
+++ b/lambdas/link_fetcher/tests/conftest.py
@@ -167,7 +167,7 @@ def generate_mock_responses_for_one_day(mock_search_response):
         "&startDate=2019-12-02T00:00:00Z"
         "&sortParam=published"
         "&sortOrder=desc"
-        "&maxRecords=100"
+        "&maxRecords=2000"
         "&index={1}"
         "&exactCount=1"
     )

--- a/lambdas/link_fetcher/tests/test_link_fetcher_handler.py
+++ b/lambdas/link_fetcher/tests/test_link_fetcher_handler.py
@@ -47,7 +47,7 @@ def test_that_link_fetcher_handler_generates_correct_query_parameters():
         "startDate": "2019-12-02T00:00:00Z",
         "sortParam": "published",
         "sortOrder": "desc",
-        "maxRecords": 100,
+        "maxRecords": 2000,
         # `start` is 0-based, but `index` is 1-based, so we must add 1 when
         # computing the page number from the `start` index.
         "index": 1,
@@ -92,7 +92,7 @@ def test_that_link_fetcher_handler_gets_correct_query_results(mock_search_respon
             "&startDate=2019-12-02T00:00:00Z"
             "&sortParam=published"
             "&sortOrder=desc"
-            "&maxRecords=100"
+            "&maxRecords=2000"
             "&index=1"
             "&exactCount=1"
         ),
@@ -124,7 +124,7 @@ def test_that_link_fetcher_handler_defaults_total_results_to_neg1_when_missing(
             "&startDate=2019-12-02T00:00:00Z"
             "&sortParam=published"
             "&sortOrder=desc"
-            "&maxRecords=100"
+            "&maxRecords=2000"
             "&index=1"
             "&exactCount=1"
         ),
@@ -155,7 +155,7 @@ def test_that_link_fetcher_handler_defaults_total_results_to_neg1_when_null(
             "&startDate=2019-12-02T00:00:00Z"
             "&sortParam=published"
             "&sortOrder=desc"
-            "&maxRecords=100"
+            "&maxRecords=2000"
             "&index=1"
             "&exactCount=1"
         ),
@@ -186,7 +186,7 @@ def test_that_link_fetcher_handler_gets_correct_query_results_when_no_imagery_le
             "&startDate=2019-12-02T00:00:00Z"
             "&sortParam=published"
             "&sortOrder=desc"
-            "&maxRecords=100"
+            "&maxRecords=2000"
             "&index=1"
             "&exactCount=1"
         ),


### PR DESCRIPTION
## What I am changing

This PR is motivated by this issue, https://github.com/NASA-IMPACT/hls-sentinel2-downloader-serverless/issues/45

Specifically I am updating the OpenSearch limit to the maximum value (2000) to quickly mitigate an issue surfaced when ESA updated the maximum query offset we could apply. This fix relies on an assumption that there are less than 12,000 search results for a given day. This assumption matches what I've seen for queries over the last week where we're getting between ~10,000 and ~10,500 total results.

## How I did it

* Updated `maxResults` to the maximum allowed `maxResults=2000`
* Updated tests to reflect the updated query

## How you can test it

Unit tests have been updated,
```
cd lambdas/link_fetcher
make test
```