### PR TITLE
fix: avoid running final query when fetched_links == total_results

### DIFF
--- a/lambdas/link_fetcher/Pipfile
+++ b/lambdas/link_fetcher/Pipfile
@@ -26,6 +26,7 @@ mypy = "==1.6.0"
 types-requests = "==2.31.0"
 types-humanfriendly = "*"
 ruff = "==0.7.1"
+pytest-mock = "*"
 
 [requires]
 python_version = "3.11"

--- a/lambdas/link_fetcher/Pipfile.lock
+++ b/lambdas/link_fetcher/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "72bdce1436bedb770bbee36ae3ac0b7906c80706726f6a408592f7b945935dfc"
+            "sha256": "662e276132993663d336cd1af445ea58553e2a20ffe15e2fdc2ac315be4d97d4"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -27,11 +27,11 @@
         },
         "botocore": {
             "hashes": [
-                "sha256:05f4493119a96799ff84d43e78691efac3177e1aec8840cca99511de940e342a",
-                "sha256:f8f703463d3cd8b6abe2bedc443a7ab29f0e2ff1588a2e83164b108748645547"
+                "sha256:c83983c196b4452dd7f298e68a9a224bc8fd58075b60133532848813826611af",
+                "sha256:d782e02f2949889cf97a140a89cd5e9363d0e4b0153db51faf7fc16305c6e0e1"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.35.47"
+            "version": "==1.35.67"
         },
         "certifi": {
             "hashes": [
@@ -284,11 +284,11 @@
         },
         "s3transfer": {
             "hashes": [
-                "sha256:263ed587a5803c6c708d3ce44dc4dfedaab4c1a32e8329bab818933d79ddcf5d",
-                "sha256:4f50ed74ab84d474ce614475e0b8d5047ff080810aac5d01ea25231cfc944b0c"
+                "sha256:244a76a24355363a68164241438de1b72f8781664920260c48465896b712a41e",
+                "sha256:29edc09801743c21eb5ecbc617a152df41d3c287f67b615f73e5f750583666a7"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==0.10.3"
+            "version": "==0.10.4"
         },
         "six": {
             "hashes": [
@@ -395,11 +395,11 @@
         },
         "botocore": {
             "hashes": [
-                "sha256:05f4493119a96799ff84d43e78691efac3177e1aec8840cca99511de940e342a",
-                "sha256:f8f703463d3cd8b6abe2bedc443a7ab29f0e2ff1588a2e83164b108748645547"
+                "sha256:c83983c196b4452dd7f298e68a9a224bc8fd58075b60133532848813826611af",
+                "sha256:d782e02f2949889cf97a140a89cd5e9363d0e4b0153db51faf7fc16305c6e0e1"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.35.47"
+            "version": "==1.35.67"
         },
         "certifi": {
             "hashes": [
@@ -598,71 +598,71 @@
                 "toml"
             ],
             "hashes": [
-                "sha256:00a1d69c112ff5149cabe60d2e2ee948752c975d95f1e1096742e6077affd376",
-                "sha256:023bf8ee3ec6d35af9c1c6ccc1d18fa69afa1cb29eaac57cb064dbb262a517f9",
-                "sha256:0294ca37f1ba500667b1aef631e48d875ced93ad5e06fa665a3295bdd1d95111",
-                "sha256:06babbb8f4e74b063dbaeb74ad68dfce9186c595a15f11f5d5683f748fa1d172",
-                "sha256:0809082ee480bb8f7416507538243c8863ac74fd8a5d2485c46f0f7499f2b491",
-                "sha256:0b3fb02fe73bed561fa12d279a417b432e5b50fe03e8d663d61b3d5990f29546",
-                "sha256:0b58c672d14f16ed92a48db984612f5ce3836ae7d72cdd161001cc54512571f2",
-                "sha256:0bcd1069e710600e8e4cf27f65c90c7843fa8edfb4520fb0ccb88894cad08b11",
-                "sha256:1032e178b76a4e2b5b32e19d0fd0abbce4b58e77a1ca695820d10e491fa32b08",
-                "sha256:11a223a14e91a4693d2d0755c7a043db43d96a7450b4f356d506c2562c48642c",
-                "sha256:12394842a3a8affa3ba62b0d4ab7e9e210c5e366fbac3e8b2a68636fb19892c2",
-                "sha256:182e6cd5c040cec0a1c8d415a87b67ed01193ed9ad458ee427741c7d8513d963",
-                "sha256:1d5b8007f81b88696d06f7df0cb9af0d3b835fe0c8dbf489bad70b45f0e45613",
-                "sha256:1f76846299ba5c54d12c91d776d9605ae33f8ae2b9d1d3c3703cf2db1a67f2c0",
-                "sha256:27fb4a050aaf18772db513091c9c13f6cb94ed40eacdef8dad8411d92d9992db",
-                "sha256:29155cd511ee058e260db648b6182c419422a0d2e9a4fa44501898cf918866cf",
-                "sha256:29fc0f17b1d3fea332f8001d4558f8214af7f1d87a345f3a133c901d60347c73",
-                "sha256:2b6b4c83d8e8ea79f27ab80778c19bc037759aea298da4b56621f4474ffeb117",
-                "sha256:2fdef0d83a2d08d69b1f2210a93c416d54e14d9eb398f6ab2f0a209433db19e1",
-                "sha256:3c65d37f3a9ebb703e710befdc489a38683a5b152242664b973a7b7b22348a4e",
-                "sha256:4f704f0998911abf728a7783799444fcbbe8261c4a6c166f667937ae6a8aa522",
-                "sha256:51b44306032045b383a7a8a2c13878de375117946d68dcb54308111f39775a25",
-                "sha256:53d202fd109416ce011578f321460795abfe10bb901b883cafd9b3ef851bacfc",
-                "sha256:58809e238a8a12a625c70450b48e8767cff9eb67c62e6154a642b21ddf79baea",
-                "sha256:5915fcdec0e54ee229926868e9b08586376cae1f5faa9bbaf8faf3561b393d52",
-                "sha256:5beb1ee382ad32afe424097de57134175fea3faf847b9af002cc7895be4e2a5a",
-                "sha256:5f8ae553cba74085db385d489c7a792ad66f7f9ba2ee85bfa508aeb84cf0ba07",
-                "sha256:5fbd612f8a091954a0c8dd4c0b571b973487277d26476f8480bfa4b2a65b5d06",
-                "sha256:6bd818b7ea14bc6e1f06e241e8234508b21edf1b242d49831831a9450e2f35fa",
-                "sha256:6f01ba56b1c0e9d149f9ac85a2f999724895229eb36bd997b61e62999e9b0901",
-                "sha256:73d2b73584446e66ee633eaad1a56aad577c077f46c35ca3283cd687b7715b0b",
-                "sha256:7bb92c539a624cf86296dd0c68cd5cc286c9eef2d0c3b8b192b604ce9de20a17",
-                "sha256:8165b796df0bd42e10527a3f493c592ba494f16ef3c8b531288e3d0d72c1f6f0",
-                "sha256:862264b12ebb65ad8d863d51f17758b1684560b66ab02770d4f0baf2ff75da21",
-                "sha256:8902dd6a30173d4ef09954bfcb24b5d7b5190cf14a43170e386979651e09ba19",
-                "sha256:8cf717ee42012be8c0cb205dbbf18ffa9003c4cbf4ad078db47b95e10748eec5",
-                "sha256:8ed9281d1b52628e81393f5eaee24a45cbd64965f41857559c2b7ff19385df51",
-                "sha256:99b41d18e6b2a48ba949418db48159d7a2e81c5cc290fc934b7d2380515bd0e3",
-                "sha256:9cb7fa111d21a6b55cbf633039f7bc2749e74932e3aa7cb7333f675a58a58bf3",
-                "sha256:a181e99301a0ae128493a24cfe5cfb5b488c4e0bf2f8702091473d033494d04f",
-                "sha256:a413a096c4cbac202433c850ee43fa326d2e871b24554da8327b01632673a076",
-                "sha256:a6b1e54712ba3474f34b7ef7a41e65bd9037ad47916ccb1cc78769bae324c01a",
-                "sha256:ade3ca1e5f0ff46b678b66201f7ff477e8fa11fb537f3b55c3f0568fbfe6e718",
-                "sha256:b0ac3d42cb51c4b12df9c5f0dd2f13a4f24f01943627120ec4d293c9181219ba",
-                "sha256:b369ead6527d025a0fe7bd3864e46dbee3aa8f652d48df6174f8d0bac9e26e0e",
-                "sha256:b57b768feb866f44eeed9f46975f3d6406380275c5ddfe22f531a2bf187eda27",
-                "sha256:b8d3a03d9bfcaf5b0141d07a88456bb6a4c3ce55c080712fec8418ef3610230e",
-                "sha256:bc66f0bf1d7730a17430a50163bb264ba9ded56739112368ba985ddaa9c3bd09",
-                "sha256:bf20494da9653f6410213424f5f8ad0ed885e01f7e8e59811f572bdb20b8972e",
-                "sha256:c48167910a8f644671de9f2083a23630fbf7a1cb70ce939440cd3328e0919f70",
-                "sha256:c481b47f6b5845064c65a7bc78bc0860e635a9b055af0df46fdf1c58cebf8e8f",
-                "sha256:c7c8b95bf47db6d19096a5e052ffca0a05f335bc63cef281a6e8fe864d450a72",
-                "sha256:c9b8e184898ed014884ca84c70562b4a82cbc63b044d366fedc68bc2b2f3394a",
-                "sha256:cc8ff50b50ce532de2fa7a7daae9dd12f0a699bfcd47f20945364e5c31799fef",
-                "sha256:d541423cdd416b78626b55f123412fcf979d22a2c39fce251b350de38c15c15b",
-                "sha256:dab4d16dfef34b185032580e2f2f89253d302facba093d5fa9dbe04f569c4f4b",
-                "sha256:dacbc52de979f2823a819571f2e3a350a7e36b8cb7484cdb1e289bceaf35305f",
-                "sha256:df57bdbeffe694e7842092c5e2e0bc80fff7f43379d465f932ef36f027179806",
-                "sha256:ed8fe9189d2beb6edc14d3ad19800626e1d9f2d975e436f84e19efb7fa19469b",
-                "sha256:f3ddf056d3ebcf6ce47bdaf56142af51bb7fad09e4af310241e9db7a3a8022e1",
-                "sha256:f8fe4984b431f8621ca53d9380901f62bfb54ff759a1348cd140490ada7b693c",
-                "sha256:fe439416eb6380de434886b00c859304338f8b19f6f54811984f3420a2e03858"
+                "sha256:0266b62cbea568bd5e93a4da364d05de422110cbed5056d69339bd5af5685433",
+                "sha256:0573f5cbf39114270842d01872952d301027d2d6e2d84013f30966313cadb529",
+                "sha256:0ddcb70b3a3a57581b450571b31cb774f23eb9519c2aaa6176d3a84c9fc57671",
+                "sha256:108bb458827765d538abcbf8288599fee07d2743357bdd9b9dad456c287e121e",
+                "sha256:14045b8bfd5909196a90da145a37f9d335a5d988a83db34e80f41e965fb7cb42",
+                "sha256:1a5407a75ca4abc20d6252efeb238377a71ce7bda849c26c7a9bece8680a5d99",
+                "sha256:2bc3e45c16564cc72de09e37413262b9f99167803e5e48c6156bccdfb22c8327",
+                "sha256:2d608a7808793e3615e54e9267519351c3ae204a6d85764d8337bd95993581a8",
+                "sha256:34d23e28ccb26236718a3a78ba72744212aa383141961dd6825f6595005c8b06",
+                "sha256:37a15573f988b67f7348916077c6d8ad43adb75e478d0910957394df397d2874",
+                "sha256:3c0317288f032221d35fa4cbc35d9f4923ff0dfd176c79c9b356e8ef8ef2dff4",
+                "sha256:3c42ec2c522e3ddd683dec5cdce8e62817afb648caedad9da725001fa530d354",
+                "sha256:3c6b24007c4bcd0b19fac25763a7cac5035c735ae017e9a349b927cfc88f31c1",
+                "sha256:40cca284c7c310d622a1677f105e8507441d1bb7c226f41978ba7c86979609ab",
+                "sha256:46f21663e358beae6b368429ffadf14ed0a329996248a847a4322fb2e35d64d3",
+                "sha256:49ed5ee4109258973630c1f9d099c7e72c5c36605029f3a91fe9982c6076c82b",
+                "sha256:5c95e0fa3d1547cb6f021ab72f5c23402da2358beec0a8e6d19a368bd7b0fb37",
+                "sha256:5dd4e4a49d9c72a38d18d641135d2fb0bdf7b726ca60a103836b3d00a1182acd",
+                "sha256:5e444b8e88339a2a67ce07d41faabb1d60d1004820cee5a2c2b54e2d8e429a0f",
+                "sha256:60dcf7605c50ea72a14490d0756daffef77a5be15ed1b9fea468b1c7bda1bc3b",
+                "sha256:623e6965dcf4e28a3debaa6fcf4b99ee06d27218f46d43befe4db1c70841551c",
+                "sha256:673184b3156cba06154825f25af33baa2671ddae6343f23175764e65a8c4c30b",
+                "sha256:6cf96ceaa275f071f1bea3067f8fd43bec184a25a962c754024c973af871e1b7",
+                "sha256:70a56a2ec1869e6e9fa69ef6b76b1a8a7ef709972b9cc473f9ce9d26b5997ce3",
+                "sha256:77256ad2345c29fe59ae861aa11cfc74579c88d4e8dbf121cbe46b8e32aec808",
+                "sha256:796c9b107d11d2d69e1849b2dfe41730134b526a49d3acb98ca02f4985eeff7a",
+                "sha256:7c07de0d2a110f02af30883cd7dddbe704887617d5c27cf373362667445a4c76",
+                "sha256:7e61b0e77ff4dddebb35a0e8bb5a68bf0f8b872407d8d9f0c726b65dfabe2469",
+                "sha256:82c809a62e953867cf57e0548c2b8464207f5f3a6ff0e1e961683e79b89f2c55",
+                "sha256:850cfd2d6fc26f8346f422920ac204e1d28814e32e3a58c19c91980fa74d8289",
+                "sha256:87ea64b9fa52bf395272e54020537990a28078478167ade6c61da7ac04dc14bc",
+                "sha256:90746521206c88bdb305a4bf3342b1b7316ab80f804d40c536fc7d329301ee13",
+                "sha256:951aade8297358f3618a6e0660dc74f6b52233c42089d28525749fc8267dccd2",
+                "sha256:963e4a08cbb0af6623e61492c0ec4c0ec5c5cf74db5f6564f98248d27ee57d30",
+                "sha256:987a8e3da7da4eed10a20491cf790589a8e5e07656b6dc22d3814c4d88faf163",
+                "sha256:9c2eb378bebb2c8f65befcb5147877fc1c9fbc640fc0aad3add759b5df79d55d",
+                "sha256:a1ab9763d291a17b527ac6fd11d1a9a9c358280adb320e9c2672a97af346ac2c",
+                "sha256:a3b925300484a3294d1c70f6b2b810d6526f2929de954e5b6be2bf8caa1f12c1",
+                "sha256:acbb8af78f8f91b3b51f58f288c0994ba63c646bc1a8a22ad072e4e7e0a49f1c",
+                "sha256:ad32a981bcdedb8d2ace03b05e4fd8dace8901eec64a532b00b15217d3677dd2",
+                "sha256:aee9cf6b0134d6f932d219ce253ef0e624f4fa588ee64830fcba193269e4daa3",
+                "sha256:af05bbba896c4472a29408455fe31b3797b4d8648ed0a2ccac03e074a77e2314",
+                "sha256:b6cce5c76985f81da3769c52203ee94722cd5d5889731cd70d31fee939b74bf0",
+                "sha256:bb684694e99d0b791a43e9fc0fa58efc15ec357ac48d25b619f207c41f2fd384",
+                "sha256:c132b5a22821f9b143f87446805e13580b67c670a548b96da945a8f6b4f2efbb",
+                "sha256:c296263093f099da4f51b3dff1eff5d4959b527d4f2f419e16508c5da9e15e8c",
+                "sha256:c973b2fe4dc445cb865ab369df7521df9c27bf40715c837a113edaa2aa9faf45",
+                "sha256:cdd94501d65adc5c24f8a1a0eda110452ba62b3f4aeaba01e021c1ed9cb8f34a",
+                "sha256:d79d4826e41441c9a118ff045e4bccb9fdbdcb1d02413e7ea6eb5c87b5439d24",
+                "sha256:dbba8210f5067398b2c4d96b4e64d8fb943644d5eb70be0d989067c8ca40c0f8",
+                "sha256:df002e59f2d29e889c37abd0b9ee0d0e6e38c24f5f55d71ff0e09e3412a340ec",
+                "sha256:dfd14bcae0c94004baba5184d1c935ae0d1231b8409eb6c103a5fd75e8ecdc56",
+                "sha256:e25bacb53a8c7325e34d45dddd2f2fbae0dbc230d0e2642e264a64e17322a777",
+                "sha256:e2c8e3384c12dfa19fa9a52f23eb091a8fad93b5b81a41b14c17c78e23dd1d8b",
+                "sha256:e5f2a0f161d126ccc7038f1f3029184dbdf8f018230af17ef6fd6a707a5b881f",
+                "sha256:e69ad502f1a2243f739f5bd60565d14a278be58be4c137d90799f2c263e7049a",
+                "sha256:ead9b9605c54d15be228687552916c89c9683c215370c4a44f1f217d2adcc34d",
+                "sha256:f07ff574986bc3edb80e2c36391678a271d555f91fd1d332a1e0f4b5ea4b6ea9",
+                "sha256:f2c7a045eef561e9544359a0bf5784b44e55cefc7261a20e730baa9220c83413",
+                "sha256:f3e8796434a8106b3ac025fd15417315d7a58ee3e600ad4dbcfddc3f4b14342c",
+                "sha256:f63e21ed474edd23f7501f89b53280014436e383a14b9bd77a648366c81dce7b",
+                "sha256:fd49c01e5057a451c30c9b892948976f5d38f2cbd04dc556a82743ba8e27ed8c"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==7.6.4"
+            "version": "==7.6.7"
         },
         "cryptography": {
             "hashes": [
@@ -956,11 +956,11 @@
         },
         "packaging": {
             "hashes": [
-                "sha256:026ed72c8ed3fcce5bf8950572258698927fd1dbda10a5e981cdf0ac37f4f002",
-                "sha256:5b8f2217dbdbd2f7f384c41c628544e6d52f2d0f53c6d0c3ea61aa5d1d7ff124"
+                "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759",
+                "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==24.1"
+            "version": "==24.2"
         },
         "pluggy": {
             "hashes": [
@@ -1020,6 +1020,15 @@
             "index": "pypi",
             "markers": "python_version >= '3.6'",
             "version": "==2.0.1"
+        },
+        "pytest-mock": {
+            "hashes": [
+                "sha256:0b72c38033392a5f4621342fe11e9219ac11ec9d375f8e2a0c164539e0d70f6f",
+                "sha256:2719255a1efeceadbc056d6bf3df3d1c5015530fb40cf347c0f9afac88410bd0"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==3.14.0"
         },
         "python-dateutil": {
             "hashes": [
@@ -1133,11 +1142,11 @@
         },
         "s3transfer": {
             "hashes": [
-                "sha256:263ed587a5803c6c708d3ce44dc4dfedaab4c1a32e8329bab818933d79ddcf5d",
-                "sha256:4f50ed74ab84d474ce614475e0b8d5047ff080810aac5d01ea25231cfc944b0c"
+                "sha256:244a76a24355363a68164241438de1b72f8781664920260c48465896b712a41e",
+                "sha256:29edc09801743c21eb5ecbc617a152df41d3c287f67b615f73e5f750583666a7"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==0.10.3"
+            "version": "==0.10.4"
         },
         "six": {
             "hashes": [
@@ -1190,12 +1199,12 @@
         },
         "types-humanfriendly": {
             "hashes": [
-                "sha256:c0ca654b16ff36ed4c059152085a76c9909272f5ea6ac03cdb7e59b5dcd392c7",
-                "sha256:c87b2eb8ec2ab1ae51cb3cc2c0efee31622a6711b2a7627d8109e22b4cfd4366"
+                "sha256:9fd55a80481f3def1a1fa1f057e765f578bc3dde2d9c7034ccf4c6ca9177e8c1",
+                "sha256:c2cab19b77c7a81e4005a3512c7f352310406d6929f300487c423e4df5a3ec3d"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.7'",
-            "version": "==10.0.1.11"
+            "markers": "python_version >= '3.8'",
+            "version": "==10.0.1.20241105"
         },
         "types-pyyaml": {
             "hashes": [
@@ -1238,11 +1247,11 @@
         },
         "werkzeug": {
             "hashes": [
-                "sha256:02c9eb92b7d6c06f31a782811505d2157837cea66aaede3e217c7c27c039476c",
-                "sha256:34f2371506b250df4d4f84bfe7b0921e4762525762bbd936614909fe25cd7306"
+                "sha256:54b78bf3716d19a65be4fceccc0d1d7b89e608834989dfae50ea87564639213e",
+                "sha256:60723ce945c19328679790e3282cc758aa4a6040e4bb330f53d30fa546d44746"
             ],
-            "markers": "python_version >= '3.8'",
-            "version": "==3.0.4"
+            "markers": "python_version >= '3.9'",
+            "version": "==3.1.3"
         },
         "xmltodict": {
             "hashes": [

--- a/lambdas/link_fetcher/handler.py
+++ b/lambdas/link_fetcher/handler.py
@@ -102,7 +102,9 @@ def _handler(
         # Don't search again if we've fetched all of the totalResults to help prevent
         # queries that exceed maximum offset (10,000)
         if fetched_links == total_results:
-            print(f"Completed fetching {fetched_links}/{total_results} links for {query_date}. Exiting.")
+            print(
+                f"Completed fetching {fetched_links}/{total_results} links for {query_date}. Exiting."
+            )
             break
 
         search_results, _ = get_page_for_query_and_total_results(params)

--- a/lambdas/link_fetcher/tests/conftest.py
+++ b/lambdas/link_fetcher/tests/conftest.py
@@ -183,6 +183,16 @@ def generate_mock_responses_for_one_day(mock_search_response):
     search_response_2020_empty = deepcopy(search_response_2020)
     search_response_2020_empty["features"] = []
 
+    # Set totalResults to the number we're going to mock
+    total_results = (
+        len(search_response_2020_page1["features"]) +
+        len(search_response_2020_page2["features"]) +
+        len(search_response_2020_empty["features"])
+    )
+    search_response_2020_page1["properties"]["totalResults"] = total_results
+    search_response_2020_page2["properties"]["totalResults"] = total_results
+    search_response_2020_empty["properties"]["totalResults"] = total_results
+
     # Create responses for sentinel query based on year and start point
     responses.add(
         responses.GET,

--- a/lambdas/link_fetcher/tests/conftest.py
+++ b/lambdas/link_fetcher/tests/conftest.py
@@ -185,9 +185,9 @@ def generate_mock_responses_for_one_day(mock_search_response):
 
     # Set totalResults to the number we're going to mock
     total_results = (
-        len(search_response_2020_page1["features"]) +
-        len(search_response_2020_page2["features"]) +
-        len(search_response_2020_empty["features"])
+        len(search_response_2020_page1["features"])
+        + len(search_response_2020_page2["features"])
+        + len(search_response_2020_empty["features"])
     )
     search_response_2020_page1["properties"]["totalResults"] = total_results
     search_response_2020_page2["properties"]["totalResults"] = total_results

--- a/lambdas/link_fetcher/tests/test_link_fetcher_handler.py
+++ b/lambdas/link_fetcher/tests/test_link_fetcher_handler.py
@@ -488,7 +488,7 @@ def test_that_link_fetcher_handler_correctly_functions(
         .first()
     )
     assert granule_count is not None
-    assert_that(granule_count.available_links).is_equal_to(6786)
+    assert_that(granule_count.available_links).is_equal_to(10)
     assert_that(granule_count.fetched_links).is_equal_to(10)
     assert_that(granule_count.last_fetched_time).is_equal_to(datetime.now())
 
@@ -539,7 +539,7 @@ def test_that_link_fetcher_handler_bails_early(
         .first()
     )
     assert granule_count is not None
-    assert_that(granule_count.available_links).is_equal_to(6786)
+    assert_that(granule_count.available_links).is_equal_to(10)
     assert_that(granule_count.fetched_links).is_equal_to(5)
     assert_that(granule_count.last_fetched_time).is_equal_to(datetime.now())
 

--- a/lambdas/link_fetcher/tests/test_link_fetcher_handler.py
+++ b/lambdas/link_fetcher/tests/test_link_fetcher_handler.py
@@ -577,11 +577,14 @@ def test_that_link_fetcher_handler_doesnt_query_after_fetching_total_results(
     search offset (10,000). See,
     https://github.com/NASA-IMPACT/hls-sentinel2-downloader-serverless/issues/45
     """
+
     class MockContext:
         def get_remaining_time_in_millis(self) -> int:
             return MIN_REMAINING_MILLIS
 
-    spy_get_page_for_query_and_total_results = mocker.spy(handler, "get_page_for_query_and_total_results")
+    spy_get_page_for_query_and_total_results = mocker.spy(
+        handler, "get_page_for_query_and_total_results"
+    )
 
     result = _handler({"query_date": "2020-01-01"}, MockContext(), lambda: db_session)
 
@@ -591,6 +594,7 @@ def test_that_link_fetcher_handler_doesnt_query_after_fetching_total_results(
     # Check our spy on get_page_for_query_and_total_results -> it should not have been
     # called with index={totalResults} where `totalResults=10` from our mocked response
     index_call_args = [
-        call.args[0]["index"] for call in spy_get_page_for_query_and_total_results.call_args_list
+        call.args[0]["index"]
+        for call in spy_get_page_for_query_and_total_results.call_args_list
     ]
     assert 10 not in index_call_args


### PR DESCRIPTION
## What I am changing

This PR is a followup to #46 and seeks to fully fix #45.

PR #46 fixed fetching all of the links from ESA after they changed how pagination works, but didn't fully fix one piece that is essential to the Lambda function executing successfully. Specifically without this PR our link fetcher will still run a final query even after fetching all of the links that the API said are available.

To walk through an example ~> assume the API has a query offset limit of 100, and we page through in batches of 50,
```
Query 1:
  fetched_links = 0
  total_results = 100
  index = 1  # "success
Query 2:
  fetched_links = 50
  total_results = 100
  index = 51  # success
Query 3:
  fetched_links = 100
  total_results = 100
  index = 101  # failure! we don't need to run this query!
```

To avoid this issue, this PR changes the link fetching behavior to exit once we've fetched all of the `totalResults`.

## How I did it

* Track "fetched_links" and added a conditional to exit early when `fetched_links == total_results`
* Updated the "mock search result for one day" to be more realistic with respect to `totalResults` (n=10)
* Updated 2 test assertions to match the total results returned by our mocked search result (from 6786 to 10)
* Added a new test to ensure we don't fetch links once we've hit the total search results

## How you can test it

I added a unit test for this behavior that checks we do NOT run an additional query that has an `index` greater than the total result count.

```
$ cd lambdas/link_fetcher
$ pipenv run pytest tests/test_link_fetcher_handler.py -k doesnt_query
```

I also updated the link fetcher Lambda currently running and used this to get successful executions of our StepFunction ✅ 